### PR TITLE
Fixed filter regexps for blocks

### DIFF
--- a/addons/binding/org.openhab.binding.plclogo/ESH-INF/config/analog.xml
+++ b/addons/binding/org.openhab.binding.plclogo/ESH-INF/config/analog.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:plclogo:analog">
-		<parameter name="block" type="text" pattern="AI[1-8]|NAI[1-32]|AQ[1-8]|NAQ[1-16]|AM[1-64]|VD(\d|[1-9]\d|[1-7]\d{2}|8[0-3]\d|84[0-7])|VW(\d|[1-9]\d|[1-7]\d{2}|8[0-4]\d)">
+		<parameter name="block" type="text" pattern="AI[1-8]|NAI([1-9]|[1-2]\d|3[0-2])|AQ[1-8]|NAQ([1-9]|1[0-6])|AM([1-9]|[1-5]\d|6[0-4])|VD(\d|[1-9]\d|[1-7]\d{2}|8[0-3]\d|84[0-7])|VW(\d|[1-9]\d|[1-7]\d{2}|8[0-4]\d)">
 			<label>LOGO! block/memory</label>
 			<description>LOGO! block or memory address</description>
 			<required>true</required>

--- a/addons/binding/org.openhab.binding.plclogo/ESH-INF/config/digital.xml
+++ b/addons/binding/org.openhab.binding.plclogo/ESH-INF/config/digital.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:plclogo:digital">
-		<parameter name="block" type="text" pattern="I[1-24]|NI[1-64]|Q[1-20]|NQ[1-64]|M[1-64]|VB(\d|[1-9]\d|[1-7]\d{2}|8[0-4]\d|850)\.[0-7]">
+		<parameter name="block" type="text" pattern="I([1-9]|1\d|2[0-4])|NI([1-9]|[1-5]\d|6[0-4])|Q([1-9]|1\d|20)|NQ([1-9]|[1-5]\d|6[0-4])|M([1-9]|[1-5]\d|6[0-4])|VB(\d|[1-9]\d|[1-7]\d{2}|8[0-4]\d|850)\.[0-7]">
 			<label>LOGO! block/memory</label>
 			<description>LOGO! block or memory address</description>
 			<required>true</required>


### PR DESCRIPTION
The original regexps didn't match block names correctly.
Example:
`NAI[1-32]` means "string NAI" followed by "digit from range 1-3 or 2" so it will match only `NAI1`, `NAI2` and `NAI3` but will not match e.g. `NAI9` or `NAI12`.